### PR TITLE
feat: 시간표 생성 로직 생성

### DIFF
--- a/src/main/java/com/gpyeong/core/domain/curriculum/application/dto/response/SectionResponse.java
+++ b/src/main/java/com/gpyeong/core/domain/curriculum/application/dto/response/SectionResponse.java
@@ -5,7 +5,7 @@ import com.gpyeong.core.domain.curriculum.domain.entity.DayOfWeek;
 import com.gpyeong.core.domain.curriculum.domain.entity.MeetingTime;
 import com.gpyeong.core.domain.curriculum.domain.entity.Section;
 
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record SectionResponse(
@@ -31,8 +31,8 @@ public record SectionResponse(
 
     public record MeetingTimeResponse(
             DayOfWeek dayOfWeek,
-            LocalTime startTime,
-            LocalTime endTime) {
+            LocalDateTime startTime,
+            LocalDateTime endTime) {
         public static MeetingTimeResponse from(MeetingTime meetingTime) {
             return new MeetingTimeResponse(
                     meetingTime.getDayOfWeek(),

--- a/src/main/java/com/gpyeong/core/domain/curriculum/domain/entity/MeetingTime.java
+++ b/src/main/java/com/gpyeong/core/domain/curriculum/domain/entity/MeetingTime.java
@@ -1,6 +1,6 @@
 package com.gpyeong.core.domain.curriculum.domain.entity;
 
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -12,10 +12,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class MeetingTime {
     private DayOfWeek dayOfWeek;
-    private LocalTime startTime;
-    private LocalTime endTime;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
 
-    public static MeetingTime of(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime) {
+    public static MeetingTime of(DayOfWeek dayOfWeek, LocalDateTime startTime, LocalDateTime endTime) {
         return new MeetingTime(
                 dayOfWeek,
                 startTime,

--- a/src/main/java/com/gpyeong/core/domain/curriculum/domain/repository/SectionRepository.java
+++ b/src/main/java/com/gpyeong/core/domain/curriculum/domain/repository/SectionRepository.java
@@ -8,5 +8,7 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 public interface SectionRepository extends MongoRepository<Section, String> {
     List<Section> findBySubjectId(String subjectId);
 
+    List<Section> findBySubjectIdIn(List<String> subjectIds);
+
     List<Section> findByYearIdAndSemester(String yearId, SemesterEnum semester);
 }

--- a/src/main/java/com/gpyeong/core/domain/curriculum/domain/repository/SubjectRepository.java
+++ b/src/main/java/com/gpyeong/core/domain/curriculum/domain/repository/SubjectRepository.java
@@ -2,7 +2,8 @@ package com.gpyeong.core.domain.curriculum.domain.repository;
 
 import com.gpyeong.core.domain.curriculum.domain.entity.Subject;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import java.util.List;
 
 public interface SubjectRepository extends MongoRepository<Subject, String> {
-    java.util.List<Subject> findByCategoryIdIn(java.util.List<String> categoryIds);
+    List<Subject> findByCategoryIdIn(java.util.List<String> categoryIds);
 }

--- a/src/main/java/com/gpyeong/core/domain/curriculum/domain/repository/SubjectRepository.java
+++ b/src/main/java/com/gpyeong/core/domain/curriculum/domain/repository/SubjectRepository.java
@@ -4,4 +4,5 @@ import com.gpyeong.core.domain.curriculum.domain.entity.Subject;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface SubjectRepository extends MongoRepository<Subject, String> {
+    java.util.List<Subject> findByCategoryIdIn(java.util.List<String> categoryIds);
 }

--- a/src/main/java/com/gpyeong/core/domain/timetable/application/dto/request/TimetableGenerationRequest.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/application/dto/request/TimetableGenerationRequest.java
@@ -1,0 +1,34 @@
+package com.gpyeong.core.domain.timetable.application.dto.request;
+
+import com.gpyeong.core.domain.common.domain.entity.SemesterEnum;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record TimetableGenerationRequest(
+        @Schema(description = "대상 연도 ID", example = "2025")
+        String yearId,
+
+        @Schema(description = "대상 학기", example = "FIRST_SEMESTER")
+        SemesterEnum semester,
+
+        @Schema(description = "목표 학점", example = "18")
+        Integer targetCredits,
+
+        @Schema(description = "필수 포함 과목 ID 목록", example = "[\"subject-id-1\"]")
+        List<String> requiredSubjectIds,
+
+        @Schema(description = "선호 교양 카테고리 ID 목록", example = "[\"category-id-1\"]")
+        List<String> preferredCategoryIds,
+
+        @Schema(description = "공강 희망 요일", example = "[\"FRI\"]")
+        List<String> preferredDayOffs,
+
+        @Schema(description = "1교시(09:00) 수업 회피 여부", example = "true")
+        boolean avoidMorning
+) {
+    public TimetableGenerationRequest {
+        if (targetCredits != null && targetCredits < 0) {
+            throw new IllegalArgumentException("목표 학점은 0 이상이어야 합니다.");
+        }
+    }
+}

--- a/src/main/java/com/gpyeong/core/domain/timetable/application/dto/response/TimetableGenerationResponse.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/application/dto/response/TimetableGenerationResponse.java
@@ -1,0 +1,15 @@
+package com.gpyeong.core.domain.timetable.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TimetableGenerationResponse(
+        @Schema(description = "생성된 시간표 ID", example = "64a1b2c...")
+        String timetableId,
+
+        @Schema(description = "결과 메시지", example = "시간표가 성공적으로 생성되었습니다.")
+        String message
+) {
+    public static TimetableGenerationResponse of(String timetableId) {
+        return new TimetableGenerationResponse(timetableId, "시간표가 성공적으로 생성되었습니다.");
+    }
+}

--- a/src/main/java/com/gpyeong/core/domain/timetable/application/dto/response/TimetableItemResponse.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/application/dto/response/TimetableItemResponse.java
@@ -1,0 +1,42 @@
+package com.gpyeong.core.domain.timetable.application.dto.response;
+
+import com.gpyeong.core.domain.curriculum.domain.entity.DayOfWeek;
+import com.gpyeong.core.domain.curriculum.domain.entity.MeetingTime;
+import com.gpyeong.core.domain.curriculum.domain.entity.Section;
+import com.gpyeong.core.domain.curriculum.domain.entity.Subject;
+import lombok.Builder;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Builder
+public record TimetableItemResponse(
+        String subjectName,
+        String professor,
+        String sectionNumber,
+        List<MeetingTimeDto> meetingTimes) {
+    public static TimetableItemResponse of(Subject subject, Section section) {
+        return TimetableItemResponse.builder()
+                .subjectName(subject.getName())
+                .professor(section.getProfessor())
+                .sectionNumber(section.getSectionNumber())
+                .meetingTimes(section.getMeetingTimes().stream()
+                        .map(MeetingTimeDto::of)
+                        .toList())
+                .build();
+    }
+
+    @Builder
+    public record MeetingTimeDto(
+            DayOfWeek dayOfWeek,
+            LocalTime startTime,
+            LocalTime endTime) {
+        public static MeetingTimeDto of(MeetingTime meetingTime) {
+            return MeetingTimeDto.builder()
+                    .dayOfWeek(meetingTime.getDayOfWeek())
+                    .startTime(meetingTime.getStartTime())
+                    .endTime(meetingTime.getEndTime())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/gpyeong/core/domain/timetable/application/dto/response/TimetableItemResponse.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/application/dto/response/TimetableItemResponse.java
@@ -6,7 +6,7 @@ import com.gpyeong.core.domain.curriculum.domain.entity.Section;
 import com.gpyeong.core.domain.curriculum.domain.entity.Subject;
 import lombok.Builder;
 
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
@@ -29,8 +29,8 @@ public record TimetableItemResponse(
     @Builder
     public record MeetingTimeDto(
             DayOfWeek dayOfWeek,
-            LocalTime startTime,
-            LocalTime endTime) {
+            LocalDateTime startTime,
+            LocalDateTime endTime) {
         public static MeetingTimeDto of(MeetingTime meetingTime) {
             return MeetingTimeDto.builder()
                     .dayOfWeek(meetingTime.getDayOfWeek())

--- a/src/main/java/com/gpyeong/core/domain/timetable/application/dto/response/TimetableResponse.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/application/dto/response/TimetableResponse.java
@@ -1,0 +1,25 @@
+package com.gpyeong.core.domain.timetable.application.dto.response;
+
+import com.gpyeong.core.domain.common.domain.entity.SemesterEnum;
+import com.gpyeong.core.domain.timetable.domain.entity.Timetable;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record TimetableResponse(
+        String timetableId,
+        String yearId,
+        SemesterEnum semester,
+        int totalCredit,
+        List<TimetableItemResponse> timetableItems) {
+    public static TimetableResponse of(Timetable timetable, List<TimetableItemResponse> items) {
+        return TimetableResponse.builder()
+                .timetableId(timetable.getTimetableId())
+                .yearId(timetable.getYearId())
+                .semester(timetable.getSemester())
+                .totalCredit(timetable.getTotalCredit())
+                .timetableItems(items)
+                .build();
+    }
+}

--- a/src/main/java/com/gpyeong/core/domain/timetable/application/usecase/TimetableGenerationUseCase.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/application/usecase/TimetableGenerationUseCase.java
@@ -2,10 +2,6 @@ package com.gpyeong.core.domain.timetable.application.usecase;
 
 import com.gpyeong.core.domain.curriculum.domain.entity.Section;
 import com.gpyeong.core.domain.timetable.application.dto.request.TimetableGenerationRequest;
-import com.gpyeong.core.domain.timetable.domain.entity.Timetable;
-import com.gpyeong.core.domain.timetable.domain.entity.TimetableItem;
-import com.gpyeong.core.domain.timetable.domain.repository.TimetableItemRepository;
-import com.gpyeong.core.domain.timetable.domain.repository.TimetableRepository;
 import com.gpyeong.core.domain.timetable.domain.service.TimetableGenerationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,15 +9,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class TimetableGenerationUseCase {
 
-    private final TimetableRepository timetableRepository;
-    private final TimetableItemRepository timetableItemRepository;
     private final TimetableGenerationService timetableGenerationService;
 
     @Transactional
@@ -29,31 +22,6 @@ public class TimetableGenerationUseCase {
 
         List<Section> bestCombination = timetableGenerationService.generateAlgorithm(request);
 
-        return saveTimetable(userId, request, bestCombination);
-    }
-
-    private String saveTimetable(Integer userId, TimetableGenerationRequest request, List<Section> sections) {
-
-        int totalCredits = timetableGenerationService.calculateTotalCredits(sections);
-
-        Timetable timetable = Timetable.builder()
-                .userId(userId)
-                .yearId(request.yearId())
-                .semester(request.semester())
-                .summary("자동 생성된 시간표")
-                .totalCredit(totalCredits)
-                .build();
-
-        Timetable saved = timetableRepository.save(timetable);
-
-        List<TimetableItem> items = sections.stream()
-                .map(s -> TimetableItem.builder()
-                        .timetableId(saved.getTimetableId())
-                        .sectionId(s.getId())
-                        .build())
-                .collect(Collectors.toList());
-
-        timetableItemRepository.saveAll(items);
-        return saved.getTimetableId();
+        return timetableGenerationService.saveTimetable(userId, request, bestCombination);
     }
 }

--- a/src/main/java/com/gpyeong/core/domain/timetable/application/usecase/TimetableGenerationUseCase.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/application/usecase/TimetableGenerationUseCase.java
@@ -1,0 +1,59 @@
+package com.gpyeong.core.domain.timetable.application.usecase;
+
+import com.gpyeong.core.domain.curriculum.domain.entity.Section;
+import com.gpyeong.core.domain.timetable.application.dto.request.TimetableGenerationRequest;
+import com.gpyeong.core.domain.timetable.domain.entity.Timetable;
+import com.gpyeong.core.domain.timetable.domain.entity.TimetableItem;
+import com.gpyeong.core.domain.timetable.domain.repository.TimetableItemRepository;
+import com.gpyeong.core.domain.timetable.domain.repository.TimetableRepository;
+import com.gpyeong.core.domain.timetable.domain.service.TimetableGenerationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TimetableGenerationUseCase {
+
+    private final TimetableRepository timetableRepository;
+    private final TimetableItemRepository timetableItemRepository;
+    private final TimetableGenerationService timetableGenerationService;
+
+    @Transactional
+    public String generate(Integer userId, TimetableGenerationRequest request) {
+
+        List<Section> bestCombination = timetableGenerationService.generateAlgorithm(request);
+
+        return saveTimetable(userId, request, bestCombination);
+    }
+
+    private String saveTimetable(Integer userId, TimetableGenerationRequest request, List<Section> sections) {
+
+        int totalCredits = timetableGenerationService.calculateTotalCredits(sections);
+
+        Timetable timetable = Timetable.builder()
+                .userId(userId)
+                .yearId(request.yearId())
+                .semester(request.semester())
+                .summary("자동 생성된 시간표")
+                .totalCredit(totalCredits)
+                .build();
+
+        Timetable saved = timetableRepository.save(timetable);
+
+        List<TimetableItem> items = sections.stream()
+                .map(s -> TimetableItem.builder()
+                        .timetableId(saved.getTimetableId())
+                        .sectionId(s.getId())
+                        .build())
+                .collect(Collectors.toList());
+
+        timetableItemRepository.saveAll(items);
+        return saved.getTimetableId();
+    }
+}

--- a/src/main/java/com/gpyeong/core/domain/timetable/application/usecase/TimetableQueryUseCase.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/application/usecase/TimetableQueryUseCase.java
@@ -1,0 +1,78 @@
+package com.gpyeong.core.domain.timetable.application.usecase;
+
+import com.gpyeong.core.domain.curriculum.domain.entity.Section;
+import com.gpyeong.core.domain.curriculum.domain.entity.Subject;
+import com.gpyeong.core.domain.curriculum.domain.repository.SectionRepository;
+import com.gpyeong.core.domain.curriculum.domain.repository.SubjectRepository;
+import com.gpyeong.core.domain.timetable.application.dto.response.TimetableItemResponse;
+import com.gpyeong.core.domain.timetable.application.dto.response.TimetableResponse;
+import com.gpyeong.core.domain.timetable.domain.entity.Timetable;
+import com.gpyeong.core.domain.timetable.domain.entity.TimetableItem;
+import com.gpyeong.core.domain.timetable.domain.repository.TimetableItemRepository;
+import com.gpyeong.core.domain.timetable.domain.repository.TimetableRepository;
+import com.gpyeong.core.global.exception.code.status.GlobalErrorStatus;
+import com.gpyeong.core.global.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TimetableQueryUseCase {
+
+    private final TimetableRepository timetableRepository;
+    private final TimetableItemRepository timetableItemRepository;
+    private final SectionRepository sectionRepository;
+    private final SubjectRepository subjectRepository;
+
+    public TimetableResponse getTimetable(String timetableId) {
+        // Timetable 조회
+        Timetable timetable = timetableRepository.findById(timetableId)
+                .orElseThrow(() -> new RestApiException(GlobalErrorStatus._BAD_REQUEST));
+
+        // Timetable Items 조회
+        List<TimetableItem> items = timetableItemRepository.findByTimetableId(timetableId);
+
+        // Section IDs 추출 및 조회
+        List<String> sectionIds = items.stream()
+                .map(TimetableItem::getSectionId)
+                .toList();
+        List<Section> sections = (List<Section>) sectionRepository.findAllById(sectionIds);
+
+        Map<String, Section> sectionMap = new java.util.HashMap<>();
+        for (Section s : sections) {
+            sectionMap.put(s.getId(), s);
+        }
+
+        // Subject IDs 추출 및 조회
+        List<String> subjectIds = sections.stream()
+                .map(Section::getSubjectId)
+                .distinct()
+                .toList();
+        List<Subject> subjects = (List<Subject>) subjectRepository.findAllById(subjectIds);
+        Map<String, Subject> subjectMap = new java.util.HashMap<>();
+        for (Subject s : subjects) {
+            subjectMap.put(s.getSubjectId(), s);
+        }
+        // Response 조립
+        List<TimetableItemResponse> itemResponses = items.stream()
+                .map(item -> {
+                    Section section = sectionMap.get(item.getSectionId());
+                    Subject subject = subjectMap.get(item.getSubjectId());
+                    // 데이터 무결성 체크 (선택사항)
+                    if (section == null || subject == null)
+                        return null;
+                    return TimetableItemResponse.of(subject, section);
+                })
+                .filter(res -> res != null)
+                .toList();
+
+        return TimetableResponse.of(timetable, itemResponses);
+    }
+}

--- a/src/main/java/com/gpyeong/core/domain/timetable/application/usecase/TimetableQueryUseCase.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/application/usecase/TimetableQueryUseCase.java
@@ -1,78 +1,19 @@
 package com.gpyeong.core.domain.timetable.application.usecase;
 
-import com.gpyeong.core.domain.curriculum.domain.entity.Section;
-import com.gpyeong.core.domain.curriculum.domain.entity.Subject;
-import com.gpyeong.core.domain.curriculum.domain.repository.SectionRepository;
-import com.gpyeong.core.domain.curriculum.domain.repository.SubjectRepository;
-import com.gpyeong.core.domain.timetable.application.dto.response.TimetableItemResponse;
 import com.gpyeong.core.domain.timetable.application.dto.response.TimetableResponse;
-import com.gpyeong.core.domain.timetable.domain.entity.Timetable;
-import com.gpyeong.core.domain.timetable.domain.entity.TimetableItem;
-import com.gpyeong.core.domain.timetable.domain.repository.TimetableItemRepository;
-import com.gpyeong.core.domain.timetable.domain.repository.TimetableRepository;
-import com.gpyeong.core.global.exception.code.status.GlobalErrorStatus;
-import com.gpyeong.core.global.exception.RestApiException;
+import com.gpyeong.core.domain.timetable.domain.service.TimetableReadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class TimetableQueryUseCase {
 
-    private final TimetableRepository timetableRepository;
-    private final TimetableItemRepository timetableItemRepository;
-    private final SectionRepository sectionRepository;
-    private final SubjectRepository subjectRepository;
+    private final TimetableReadService timetableReadService;
 
     public TimetableResponse getTimetable(String timetableId) {
-        // Timetable 조회
-        Timetable timetable = timetableRepository.findById(timetableId)
-                .orElseThrow(() -> new RestApiException(GlobalErrorStatus._BAD_REQUEST));
-
-        // Timetable Items 조회
-        List<TimetableItem> items = timetableItemRepository.findByTimetableId(timetableId);
-
-        // Section IDs 추출 및 조회
-        List<String> sectionIds = items.stream()
-                .map(TimetableItem::getSectionId)
-                .toList();
-        List<Section> sections = (List<Section>) sectionRepository.findAllById(sectionIds);
-
-        Map<String, Section> sectionMap = new java.util.HashMap<>();
-        for (Section s : sections) {
-            sectionMap.put(s.getId(), s);
-        }
-
-        // Subject IDs 추출 및 조회
-        List<String> subjectIds = sections.stream()
-                .map(Section::getSubjectId)
-                .distinct()
-                .toList();
-        List<Subject> subjects = (List<Subject>) subjectRepository.findAllById(subjectIds);
-        Map<String, Subject> subjectMap = new java.util.HashMap<>();
-        for (Subject s : subjects) {
-            subjectMap.put(s.getSubjectId(), s);
-        }
-        // Response 조립
-        List<TimetableItemResponse> itemResponses = items.stream()
-                .map(item -> {
-                    Section section = sectionMap.get(item.getSectionId());
-                    Subject subject = subjectMap.get(item.getSubjectId());
-                    // 데이터 무결성 체크 (선택사항)
-                    if (section == null || subject == null)
-                        return null;
-                    return TimetableItemResponse.of(subject, section);
-                })
-                .filter(res -> res != null)
-                .toList();
-
-        return TimetableResponse.of(timetable, itemResponses);
+        return timetableReadService.getTimetableDetail(timetableId);
     }
 }

--- a/src/main/java/com/gpyeong/core/domain/timetable/domain/entity/Timetable.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/domain/entity/Timetable.java
@@ -2,27 +2,21 @@ package com.gpyeong.core.domain.timetable.domain.entity;
 
 import com.gpyeong.core.global.common.BaseEntity;
 import com.gpyeong.core.domain.common.domain.entity.SemesterEnum;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Document(collection = "timetables")
 @Getter
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class Timetable extends BaseEntity {
     
     @Id
     private String timetableId;
     
-    private String memberId;
+    private Integer userId; // memberId에서 변경
     
     private String yearId;
     
@@ -31,7 +25,4 @@ public class Timetable extends BaseEntity {
     private String summary;
     
     private Integer totalCredit;
-    
-    @Builder.Default
-    private List<String> timetableItemIds = new ArrayList<>();
 }

--- a/src/main/java/com/gpyeong/core/domain/timetable/domain/entity/TimetableItem.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/domain/entity/TimetableItem.java
@@ -14,11 +14,13 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @NoArgsConstructor
 @Builder
 public class TimetableItem extends BaseEntity {
-    
+
     @Id
     private String timetableItemId;
-    
+
     private String timetableId;
-    
+
     private String subjectId;
+
+    private String sectionId;
 }

--- a/src/main/java/com/gpyeong/core/domain/timetable/domain/repository/TimetableItemRepository.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/domain/repository/TimetableItemRepository.java
@@ -2,6 +2,8 @@ package com.gpyeong.core.domain.timetable.domain.repository;
 
 import com.gpyeong.core.domain.timetable.domain.entity.TimetableItem;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import java.util.List;
 
 public interface TimetableItemRepository extends MongoRepository<TimetableItem, String> {
+    List<TimetableItem> findByTimetableId(String timetableId);
 }

--- a/src/main/java/com/gpyeong/core/domain/timetable/domain/repository/TimetableRepository.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/domain/repository/TimetableRepository.java
@@ -3,5 +3,8 @@ package com.gpyeong.core.domain.timetable.domain.repository;
 import com.gpyeong.core.domain.timetable.domain.entity.Timetable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.List;
+
 public interface TimetableRepository extends MongoRepository<Timetable, String> {
+    List<Timetable> findByUserId(Integer userId);
 }

--- a/src/main/java/com/gpyeong/core/domain/timetable/domain/service/TimetableGenerationService.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/domain/service/TimetableGenerationService.java
@@ -5,16 +5,24 @@ import com.gpyeong.core.domain.curriculum.domain.entity.Subject;
 import com.gpyeong.core.domain.curriculum.domain.repository.SectionRepository;
 import com.gpyeong.core.domain.curriculum.domain.repository.SubjectRepository;
 import com.gpyeong.core.domain.timetable.application.dto.request.TimetableGenerationRequest;
+import com.gpyeong.core.domain.timetable.domain.entity.Timetable;
+import com.gpyeong.core.domain.timetable.domain.entity.TimetableItem;
+import com.gpyeong.core.domain.timetable.domain.repository.TimetableItemRepository;
+import com.gpyeong.core.domain.timetable.domain.repository.TimetableRepository;
 import com.gpyeong.core.global.exception.RestApiException;
 import com.gpyeong.core.global.exception.code.status.GlobalErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.Map;
+import com.gpyeong.core.domain.curriculum.domain.entity.DayOfWeek;
+import com.gpyeong.core.domain.curriculum.domain.entity.MeetingTime;
 
 @Slf4j
 @Service
@@ -23,6 +31,8 @@ public class TimetableGenerationService {
 
     private final SectionRepository sectionRepository;
     private final SubjectRepository subjectRepository;
+    private final TimetableRepository timetableRepository;
+    private final TimetableItemRepository timetableItemRepository;
 
     private static final int SCORE_DAY_OFF = 50;
     private static final int SCORE_NO_MORNING = 30;
@@ -117,27 +127,27 @@ public class TimetableGenerationService {
         if (request.avoidMorning()) {
             boolean hasMorning = timetable.stream()
                     .flatMap(s -> s.getMeetingTimes().stream())
-                    .anyMatch(mt -> mt.getStartTime().isBefore(MORNING_LIMIT));
+                    .anyMatch(mt -> mt.getStartTime().toLocalTime().isBefore(MORNING_LIMIT));
             if (!hasMorning)
                 score += SCORE_NO_MORNING;
         }
 
         // 밀집도 (Compactness) 점수 (우주공강 패널티)
-        var meetingsByDay = timetable.stream()
+        Map<DayOfWeek, List<MeetingTime>> meetingsByDay = timetable.stream()
                 .flatMap(s -> s.getMeetingTimes().stream())
                 .collect(Collectors
-                        .groupingBy(com.gpyeong.core.domain.curriculum.domain.entity.MeetingTime::getDayOfWeek));
+                        .groupingBy(MeetingTime::getDayOfWeek));
 
         int totalGapMinutes = 0;
         for (var entry : meetingsByDay.entrySet()) {
 
-            List<com.gpyeong.core.domain.curriculum.domain.entity.MeetingTime> meetings = new ArrayList<>(
+            List<MeetingTime> meetings = new ArrayList<>(
                     entry.getValue());
             meetings.sort((m1, m2) -> m1.getStartTime().compareTo(m2.getStartTime()));
 
             for (int i = 0; i < meetings.size() - 1; i++) {
-                LocalTime endCurrent = meetings.get(i).getEndTime();
-                LocalTime startNext = meetings.get(i + 1).getStartTime();
+                LocalDateTime endCurrent = meetings.get(i).getEndTime();
+                LocalDateTime startNext = meetings.get(i + 1).getStartTime();
 
                 long gap = java.time.Duration.between(endCurrent, startNext).toMinutes();
                 if (gap > 0) {
@@ -175,7 +185,7 @@ public class TimetableGenerationService {
         List<String> allCandidateIds = allCandidates.stream().map(Subject::getSubjectId).toList();
         List<Section> allCandidateSections = sectionRepository.findBySubjectIdIn(allCandidateIds);
 
-        java.util.Map<String, Integer> subjectCreditMap = allCandidates.stream()
+        Map<String, Integer> subjectCreditMap = allCandidates.stream()
                 .collect(Collectors.toMap(Subject::getSubjectId, Subject::getCredit));
 
         // 기존 필수 과목들의 학점 정보도 맵에 추가 필요 (calculateTotalCredits에서 사용됨)
@@ -280,5 +290,29 @@ public class TimetableGenerationService {
                 .distinct()
                 .mapToInt(id -> creditMap.getOrDefault(id, 0)) // Cache hit expected
                 .sum();
+    }
+
+    public String saveTimetable(Integer userId, TimetableGenerationRequest request, List<Section> sections) {
+        int totalCredits = calculateTotalCredits(sections);
+
+        Timetable timetable = Timetable.builder()
+                .userId(userId)
+                .yearId(request.yearId())
+                .semester(request.semester())
+                .summary("자동 생성된 시간표")
+                .totalCredit(totalCredits)
+                .build();
+
+        Timetable saved = timetableRepository.save(timetable);
+
+        List<TimetableItem> items = sections.stream()
+                .map(s -> TimetableItem.builder()
+                        .timetableId(saved.getTimetableId())
+                        .sectionId(s.getId())
+                        .build())
+                .collect(Collectors.toList());
+
+        timetableItemRepository.saveAll(items);
+        return saved.getTimetableId();
     }
 }

--- a/src/main/java/com/gpyeong/core/domain/timetable/domain/service/TimetableGenerationService.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/domain/service/TimetableGenerationService.java
@@ -1,0 +1,284 @@
+package com.gpyeong.core.domain.timetable.domain.service;
+
+import com.gpyeong.core.domain.curriculum.domain.entity.Section;
+import com.gpyeong.core.domain.curriculum.domain.entity.Subject;
+import com.gpyeong.core.domain.curriculum.domain.repository.SectionRepository;
+import com.gpyeong.core.domain.curriculum.domain.repository.SubjectRepository;
+import com.gpyeong.core.domain.timetable.application.dto.request.TimetableGenerationRequest;
+import com.gpyeong.core.global.exception.RestApiException;
+import com.gpyeong.core.global.exception.code.status.GlobalErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TimetableGenerationService {
+
+    private final SectionRepository sectionRepository;
+    private final SubjectRepository subjectRepository;
+
+    private static final int SCORE_DAY_OFF = 50;
+    private static final int SCORE_NO_MORNING = 30;
+    private static final LocalTime MORNING_LIMIT = LocalTime.of(10, 0);
+
+    public List<Section> generateAlgorithm(TimetableGenerationRequest request) {
+        log.info("Starting timetable generation for user with request: {}", request);
+
+        // 필수 과목들의 모든 분반 조회
+        List<List<Section>> requiredSubjectGroups = new ArrayList<>();
+        if (request.requiredSubjectIds() != null) {
+            for (String subjectId : request.requiredSubjectIds()) {
+                List<Section> sections = sectionRepository.findBySubjectId(subjectId);
+                if (sections.isEmpty()) {
+                    log.error("No sections found for subjectId: {}", subjectId);
+                    throw new RestApiException(GlobalErrorStatus._BAD_REQUEST);
+                }
+                log.info("Found {} sections for subjectId: {}", sections.size(), subjectId);
+                requiredSubjectGroups.add(sections);
+            }
+        }
+
+        // 백트래킹 탐색 (최적 조합 찾기)
+        List<Section> bestCombination = new ArrayList<>();
+        int[] maxScore = { -1 };
+
+        backtrack(0, new ArrayList<>(), requiredSubjectGroups, request, bestCombination, maxScore);
+
+        if (bestCombination.isEmpty()) {
+            log.error("Failed to find any valid timetable combination for required subjects.");
+            throw new RestApiException(GlobalErrorStatus._BAD_REQUEST);
+        }
+
+        // 교양 과목 자동 채움 (Beam Search)
+        if (request.targetCredits() != null && request.preferredCategoryIds() != null) {
+            fillElectives(bestCombination, request);
+        }
+
+        return bestCombination;
+    }
+
+    private void backtrack(int depth, List<Section> current,
+            List<List<Section>> groups,
+            TimetableGenerationRequest request,
+            List<Section> bestCombination, int[] maxScore) {
+
+        // Base Case: 모든 과목을 선택함
+        if (depth == groups.size()) {
+            int score = calculateScore(current, request);
+            if (score > maxScore[0]) {
+                maxScore[0] = score;
+                bestCombination.clear();
+                bestCombination.addAll(new ArrayList<>(current));
+            }
+            return;
+        }
+
+        // Recursive Step
+        List<Section> candidates = groups.get(depth);
+
+        for (Section section : candidates) {
+            if (!isConflict(current, section)) {
+                current.add(section);
+                backtrack(depth + 1, current, groups, request, bestCombination, maxScore);
+                current.remove(current.size() - 1);
+            }
+        }
+    }
+
+    private boolean isConflict(List<Section> current, Section target) {
+        return current.stream().anyMatch(existing -> existing.isConflict(target));
+    }
+
+    private int calculateScore(List<Section> timetable, TimetableGenerationRequest request) {
+        int score = 0;
+
+        // 공강일 확인
+        List<String> classDays = timetable.stream()
+                .flatMap(s -> s.getMeetingTimes().stream())
+                .map(mt -> mt.getDayOfWeek().name())
+                .distinct()
+                .toList();
+
+        if (request.preferredDayOffs() != null) {
+            for (String dayOff : request.preferredDayOffs()) {
+                if (!classDays.contains(dayOff))
+                    score += SCORE_DAY_OFF;
+            }
+        }
+
+        // 오전 수업 회피
+        if (request.avoidMorning()) {
+            boolean hasMorning = timetable.stream()
+                    .flatMap(s -> s.getMeetingTimes().stream())
+                    .anyMatch(mt -> mt.getStartTime().isBefore(MORNING_LIMIT));
+            if (!hasMorning)
+                score += SCORE_NO_MORNING;
+        }
+
+        // 밀집도 (Compactness) 점수 (우주공강 패널티)
+        var meetingsByDay = timetable.stream()
+                .flatMap(s -> s.getMeetingTimes().stream())
+                .collect(Collectors
+                        .groupingBy(com.gpyeong.core.domain.curriculum.domain.entity.MeetingTime::getDayOfWeek));
+
+        int totalGapMinutes = 0;
+        for (var entry : meetingsByDay.entrySet()) {
+
+            List<com.gpyeong.core.domain.curriculum.domain.entity.MeetingTime> meetings = new ArrayList<>(
+                    entry.getValue());
+            meetings.sort((m1, m2) -> m1.getStartTime().compareTo(m2.getStartTime()));
+
+            for (int i = 0; i < meetings.size() - 1; i++) {
+                LocalTime endCurrent = meetings.get(i).getEndTime();
+                LocalTime startNext = meetings.get(i + 1).getStartTime();
+
+                long gap = java.time.Duration.between(endCurrent, startNext).toMinutes();
+                if (gap > 0) {
+                    totalGapMinutes += gap;
+                }
+            }
+        }
+
+        // 30분 공강당 1점 감점
+        score -= (totalGapMinutes / 30);
+
+        return score;
+    }
+
+    public int calculateTotalCredits(List<Section> sections) {
+        List<String> subjectIds = sections.stream()
+                .map(Section::getSubjectId)
+                .distinct()
+                .collect(Collectors.toList());
+
+        List<Subject> subjects = subjectRepository.findAllById(subjectIds);
+
+        return subjects.stream()
+                .mapToInt(Subject::getCredit)
+                .sum();
+    }
+
+    // 교양 과목 자동 채움 (Beam Search, K=5)
+    private void fillElectives(List<Section> bestCombination, TimetableGenerationRequest request) {
+        int targetCredits = request.targetCredits() != null ? request.targetCredits() : 0;
+        int BEAM_WIDTH = 5;
+
+        // 선호 카테고리의 과목 및 분반 조회 (Batch)
+        List<Subject> allCandidates = subjectRepository.findByCategoryIdIn(request.preferredCategoryIds());
+        List<String> allCandidateIds = allCandidates.stream().map(Subject::getSubjectId).toList();
+        List<Section> allCandidateSections = sectionRepository.findBySubjectIdIn(allCandidateIds);
+
+        java.util.Map<String, Integer> subjectCreditMap = allCandidates.stream()
+                .collect(Collectors.toMap(Subject::getSubjectId, Subject::getCredit));
+
+        // 기존 필수 과목들의 학점 정보도 맵에 추가 필요 (calculateTotalCredits에서 사용됨)
+        List<String> currentSubjectIds = bestCombination.stream().map(Section::getSubjectId).toList();
+        List<Subject> currentSubjects = subjectRepository.findAllById(currentSubjectIds);
+        currentSubjects.forEach(s -> subjectCreditMap.putIfAbsent(s.getSubjectId(), s.getCredit()));
+
+        List<List<Section>> beam = new ArrayList<>();
+        beam.add(new ArrayList<>(bestCombination));
+
+        boolean changed = true;
+        while (changed) {
+            changed = false;
+            List<List<Section>> nextBeam = new ArrayList<>();
+
+            for (List<Section> currentTimetable : beam) {
+                int currentCredits = calculateTotalCreditsOptimized(currentTimetable, subjectCreditMap);
+                if (currentCredits >= targetCredits) {
+                    nextBeam.add(currentTimetable); // 이미 목표 달성한 경우 유지
+                    continue;
+                }
+
+                // 이미 선택된 과목 ID 식별
+                List<String> usedSubjectIds = currentTimetable.stream()
+                        .map(Section::getSubjectId)
+                        .toList();
+
+                // 확장 가능한 후보군 탐색
+                for (Subject subject : allCandidates) {
+                    // 이미 듣고 있는 과목은 제외
+                    if (usedSubjectIds.contains(subject.getSubjectId()))
+                        continue;
+
+                    // 해당 과목의 분반들 시도
+                    List<Section> sectionsOfSubject = allCandidateSections.stream()
+                            .filter(s -> s.getSubjectId().equals(subject.getSubjectId()))
+                            .toList();
+
+                    for (Section section : sectionsOfSubject) {
+                        if (!isConflict(currentTimetable, section)) {
+                            // 새로운 시간표 후보 생성
+                            List<Section> newTimetable = new ArrayList<>(currentTimetable);
+                            newTimetable.add(section);
+                            nextBeam.add(newTimetable);
+                            changed = true;
+                        }
+                    }
+                }
+            }
+
+            if (!changed)
+                break;
+
+            // 평가 및 Beam Cutting
+            // 1순위: 학점 목표 오차(Diff) 최소화 (Math.abs(current - target))
+            // 2순위: 시간표 점수(Score) 최대화
+            nextBeam.sort((t1, t2) -> {
+                int cred1 = calculateTotalCreditsOptimized(t1, subjectCreditMap);
+                int cred2 = calculateTotalCreditsOptimized(t2, subjectCreditMap);
+                int diff1 = Math.abs(cred1 - targetCredits);
+                int diff2 = Math.abs(cred2 - targetCredits);
+
+                if (diff1 != diff2) {
+                    return Integer.compare(diff1, diff2); // 오차 작은 순
+                } else {
+                    return Integer.compare(calculateScore(t2, request), calculateScore(t1, request)); // 점수 높은 순
+
+                }
+            });
+
+            if (nextBeam.size() > BEAM_WIDTH) {
+                beam = nextBeam.subList(0, BEAM_WIDTH);
+            } else {
+                beam = nextBeam;
+            }
+        }
+
+        // 최종 선택: Beam 중 가장 좋은 것 선택
+        if (!beam.isEmpty()) {
+            beam.sort((t1, t2) -> {
+                int cred1 = calculateTotalCreditsOptimized(t1, subjectCreditMap);
+                int cred2 = calculateTotalCreditsOptimized(t2, subjectCreditMap);
+                int diff1 = Math.abs(cred1 - targetCredits);
+                int diff2 = Math.abs(cred2 - targetCredits);
+
+                if (diff1 != diff2) {
+                    return Integer.compare(diff1, diff2);
+                } else {
+                    return Integer.compare(calculateScore(t2, request), calculateScore(t1, request));
+                }
+            });
+
+            List<Section> finalBest = beam.get(0);
+            bestCombination.clear();
+            bestCombination.addAll(finalBest);
+        }
+    }
+
+    private int calculateTotalCreditsOptimized(List<Section> sections, java.util.Map<String, Integer> creditMap) {
+        return sections.stream()
+                .map(Section::getSubjectId)
+                .distinct()
+                .mapToInt(id -> creditMap.getOrDefault(id, 0)) // Cache hit expected
+                .sum();
+    }
+}

--- a/src/main/java/com/gpyeong/core/domain/timetable/domain/service/TimetableReadService.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/domain/service/TimetableReadService.java
@@ -1,0 +1,74 @@
+package com.gpyeong.core.domain.timetable.domain.service;
+
+import com.gpyeong.core.domain.curriculum.domain.entity.Section;
+import com.gpyeong.core.domain.curriculum.domain.entity.Subject;
+import com.gpyeong.core.domain.curriculum.domain.repository.SectionRepository;
+import com.gpyeong.core.domain.curriculum.domain.repository.SubjectRepository;
+import com.gpyeong.core.domain.timetable.application.dto.response.TimetableItemResponse;
+import com.gpyeong.core.domain.timetable.application.dto.response.TimetableResponse;
+import com.gpyeong.core.domain.timetable.domain.entity.Timetable;
+import com.gpyeong.core.domain.timetable.domain.entity.TimetableItem;
+import com.gpyeong.core.domain.timetable.domain.repository.TimetableItemRepository;
+import com.gpyeong.core.domain.timetable.domain.repository.TimetableRepository;
+import com.gpyeong.core.global.exception.RestApiException;
+import com.gpyeong.core.global.exception.code.status.GlobalErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TimetableReadService {
+
+    private final TimetableRepository timetableRepository;
+    private final TimetableItemRepository timetableItemRepository;
+    private final SectionRepository sectionRepository;
+    private final SubjectRepository subjectRepository;
+
+    public TimetableResponse getTimetableDetail(String timetableId) {
+        // Timetable 조회
+        Timetable timetable = timetableRepository.findById(timetableId)
+                .orElseThrow(() -> new RestApiException(GlobalErrorStatus._BAD_REQUEST));
+
+        // Timetable Items 조회
+        List<TimetableItem> items = timetableItemRepository.findByTimetableId(timetableId);
+
+        // Section IDs 추출 및 조회
+        List<String> sectionIds = items.stream()
+                .map(TimetableItem::getSectionId)
+                .toList();
+        List<Section> sections = (List<Section>) sectionRepository.findAllById(sectionIds);
+
+        Map<String, Section> sectionMap = sections.stream()
+                .collect(Collectors.toMap(Section::getId, Function.identity()));
+
+        // Subject IDs 추출 및 조회
+        List<String> subjectIds = sections.stream()
+                .map(Section::getSubjectId)
+                .distinct()
+                .toList();
+        List<Subject> subjects = (List<Subject>) subjectRepository.findAllById(subjectIds);
+        Map<String, Subject> subjectMap = subjects.stream()
+                .collect(Collectors.toMap(Subject::getSubjectId, Function.identity()));
+
+        List<TimetableItemResponse> itemResponses = items.stream()
+                .map(item -> {
+                    Section section = sectionMap.get(item.getSectionId());
+                    Subject subject = subjectMap.get(item.getSubjectId());
+                    // 데이터 무결성 체크
+                    if (section == null || subject == null)
+                        return null;
+                    return TimetableItemResponse.of(subject, section);
+                })
+                .filter(res -> res != null)
+                .toList();
+
+        return TimetableResponse.of(timetable, itemResponses);
+    }
+}

--- a/src/main/java/com/gpyeong/core/domain/timetable/ui/TimetableController.java
+++ b/src/main/java/com/gpyeong/core/domain/timetable/ui/TimetableController.java
@@ -1,0 +1,44 @@
+package com.gpyeong.core.domain.timetable.ui;
+
+import com.gpyeong.core.domain.auth.domain.entity.User;
+import com.gpyeong.core.domain.timetable.application.dto.request.TimetableGenerationRequest;
+import com.gpyeong.core.domain.timetable.application.usecase.TimetableGenerationUseCase;
+import com.gpyeong.core.global.annotation.CurrentUser;
+import com.gpyeong.core.global.common.BaseResponse;
+import com.gpyeong.core.global.swagger.TimetableApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.gpyeong.core.domain.timetable.application.dto.response.TimetableGenerationResponse;
+import com.gpyeong.core.domain.timetable.application.dto.response.TimetableResponse;
+import com.gpyeong.core.domain.timetable.application.usecase.TimetableQueryUseCase;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@RestController
+@RequestMapping("/api/timetables")
+@RequiredArgsConstructor
+public class TimetableController implements TimetableApi {
+
+    private final TimetableGenerationUseCase timetableGenerationUseCase;
+    private final TimetableQueryUseCase timetableQueryUseCase;
+
+    @Override
+    @PostMapping("/generate")
+    public BaseResponse<TimetableGenerationResponse> generateTimetable(
+            @CurrentUser User user,
+            @RequestBody TimetableGenerationRequest request) {
+
+        String timetableId = timetableGenerationUseCase.generate(user.getUserId(), request);
+
+        return BaseResponse.onSuccess(TimetableGenerationResponse.of(timetableId));
+    }
+
+    @GetMapping("/{timetableId}")
+    public BaseResponse<TimetableResponse> getTimetable(@PathVariable String timetableId) {
+        TimetableResponse response = timetableQueryUseCase.getTimetable(timetableId);
+        return BaseResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/gpyeong/core/global/config/MongoDbInitializer.java
+++ b/src/main/java/com/gpyeong/core/global/config/MongoDbInitializer.java
@@ -14,6 +14,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
 import java.util.List;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Slf4j
@@ -77,10 +79,8 @@ public class MongoDbInitializer implements CommandLineRunner {
                                         .yearId("2024")
                                         .semester(SemesterEnum.FIRST_SEMESTER)
                                         .meetingTimes(List.of(
-                                                        MeetingTime.of(DayOfWeek.MON, LocalTime.parse("09:00"),
-                                                                        LocalTime.parse("10:30")),
-                                                        MeetingTime.of(DayOfWeek.WED, LocalTime.parse("09:00"),
-                                                                        LocalTime.parse("10:30"))))
+                                                        createMeetingTime(DayOfWeek.MON, "09:00", "10:30"),
+                                                        createMeetingTime(DayOfWeek.WED, "09:00", "10:30")))
                                         .build();
                         sectionRepository.save(osSection1);
 
@@ -91,10 +91,8 @@ public class MongoDbInitializer implements CommandLineRunner {
                                         .yearId("2024")
                                         .semester(SemesterEnum.FIRST_SEMESTER)
                                         .meetingTimes(List.of(
-                                                        MeetingTime.of(DayOfWeek.TUE, LocalTime.parse("13:30"),
-                                                                        LocalTime.parse("15:00")),
-                                                        MeetingTime.of(DayOfWeek.THU, LocalTime.parse("13:30"),
-                                                                        LocalTime.parse("15:00"))))
+                                                        createMeetingTime(DayOfWeek.TUE, "13:30", "15:00"),
+                                                        createMeetingTime(DayOfWeek.THU, "13:30", "15:00")))
                                         .build();
                         sectionRepository.save(osSection2);
 
@@ -115,8 +113,7 @@ public class MongoDbInitializer implements CommandLineRunner {
                                         .yearId("2024")
                                         .semester(SemesterEnum.FIRST_SEMESTER)
                                         .meetingTimes(List.of(
-                                                        MeetingTime.of(DayOfWeek.FRI, LocalTime.parse("10:00"),
-                                                                        LocalTime.parse("13:00"))))
+                                                        createMeetingTime(DayOfWeek.FRI, "10:00", "13:00")))
                                         .build();
                         sectionRepository.save(dbSection);
 
@@ -137,10 +134,8 @@ public class MongoDbInitializer implements CommandLineRunner {
                                         .yearId("2024")
                                         .semester(SemesterEnum.FIRST_SEMESTER)
                                         .meetingTimes(List.of(
-                                                        MeetingTime.of(DayOfWeek.MON, LocalTime.parse("15:00"),
-                                                                        LocalTime.parse("16:30")),
-                                                        MeetingTime.of(DayOfWeek.WED, LocalTime.parse("15:00"),
-                                                                        LocalTime.parse("16:30"))))
+                                                        createMeetingTime(DayOfWeek.MON, "15:00", "16:30"),
+                                                        createMeetingTime(DayOfWeek.WED, "15:00", "16:30")))
                                         .build();
                         sectionRepository.save(algoSection);
 
@@ -161,8 +156,7 @@ public class MongoDbInitializer implements CommandLineRunner {
                                         .yearId("2024")
                                         .semester(SemesterEnum.FIRST_SEMESTER)
                                         .meetingTimes(List.of(
-                                                        MeetingTime.of(DayOfWeek.FRI, LocalTime.parse("14:00"),
-                                                                        LocalTime.parse("16:00"))))
+                                                        createMeetingTime(DayOfWeek.FRI, "14:00", "16:00")))
                                         .build();
                         sectionRepository.save(historySection);
 
@@ -183,12 +177,22 @@ public class MongoDbInitializer implements CommandLineRunner {
                                         .yearId("2024")
                                         .semester(SemesterEnum.FIRST_SEMESTER)
                                         .meetingTimes(List.of(
-                                                        MeetingTime.of(DayOfWeek.TUE, LocalTime.parse("10:00"),
-                                                                        LocalTime.parse("12:00"))))
+                                                        createMeetingTime(DayOfWeek.TUE, "10:00", "12:00")))
                                         .build();
                         sectionRepository.save(artSection);
 
                         log.info("시드 데이터 삽입 완료!");
                 }
+        }
+
+        private MeetingTime createMeetingTime(DayOfWeek day, String startTime, String endTime) {
+                // 2024년 3월 4일(월요일)을 기준으로 요일 계산
+                LocalDate baseDate = LocalDate.of(2024, 3, 4);
+                LocalDate date = baseDate.plusDays(day.ordinal());
+
+                return MeetingTime.of(
+                                day,
+                                date.atTime(LocalTime.parse(startTime)),
+                                date.atTime(LocalTime.parse(endTime)));
         }
 }

--- a/src/main/java/com/gpyeong/core/global/config/MongoDbInitializer.java
+++ b/src/main/java/com/gpyeong/core/global/config/MongoDbInitializer.java
@@ -21,117 +21,174 @@ import java.time.LocalTime;
 @RequiredArgsConstructor
 public class MongoDbInitializer implements CommandLineRunner {
 
-    private final MongoTemplate mongoTemplate;
-    private final SubjectRepository subjectRepository;
-    private final SectionRepository sectionRepository;
+        private final MongoTemplate mongoTemplate;
+        private final SubjectRepository subjectRepository;
+        private final SectionRepository sectionRepository;
 
-    @Override
-    public void run(String... args) throws Exception {
-        log.info("Initializing MongoDB collections...");
+        @Override
+        public void run(String... args) throws Exception {
+                log.info("Initializing MongoDB collections...");
 
-        // 1. 컬렉션 생성 로직
-        List.of("years", "users", "universities", "departments", "subjects",
-                "subject_categories", "timetables", "timetable_items",
-                "graduation_requirements", "required_subjects", "sections")
-                .forEach(this::createCollectionIfNotExists);
+                // 1. 컬렉션 생성 로직
+                List.of("years", "users", "universities", "departments", "subjects",
+                                "subject_categories", "timetables", "timetable_items",
+                                "graduation_requirements", "required_subjects", "sections")
+                                .forEach(this::createCollectionIfNotExists);
 
-        log.info("MongoDB initialization completed!");
+                log.info("MongoDB initialization completed!");
 
-        // 2. 시드 데이터 삽입
-        initSeedData();
-    }
-
-    private void createCollectionIfNotExists(String collectionName) {
-        try {
-            if (!mongoTemplate.collectionExists(collectionName)) {
-                mongoTemplate.createCollection(collectionName);
-                log.info("Created collection: {}", collectionName);
-            }
-        } catch (Exception e) {
-            log.warn("Error creating collection {}: {}", collectionName, e.getMessage());
+                // 2. 시드 데이터 삽입
+                initSeedData();
         }
-    }
 
-    private void initSeedData() {
-        // 개발/테스트용: 기존 데이터 초기화 후 다시 삽입
-        subjectRepository.deleteAll();
-        sectionRepository.deleteAll();
-
-        if (subjectRepository.count() == 0) {
-            log.info("시드 데이터 삽입 중...");
-
-            // 1. 운영체제
-            Subject os = Subject.builder()
-                    .name("운영체제")
-                    .credit(3)
-                    .semester(SemesterEnum.FIRST_SEMESTER)
-                    .build();
-            Subject savedOs = subjectRepository.save(os);
-
-            Section osSection1 = Section.builder()
-                    .subjectId(savedOs.getSubjectId())
-                    .sectionNumber("01")
-                    .professor("홍길동 교수")
-                    .yearId("2024")
-                    .semester(SemesterEnum.FIRST_SEMESTER)
-                    .meetingTimes(List.of(
-                            MeetingTime.of(DayOfWeek.MON, LocalTime.parse("09:00"), LocalTime.parse("10:30")),
-                            MeetingTime.of(DayOfWeek.WED, LocalTime.parse("09:00"), LocalTime.parse("10:30"))))
-                    .build();
-            sectionRepository.save(osSection1);
-
-            Section osSection2 = Section.builder()
-                    .subjectId(savedOs.getSubjectId())
-                    .sectionNumber("02")
-                    .professor("김철수 교수")
-                    .yearId("2024")
-                    .semester(SemesterEnum.FIRST_SEMESTER)
-                    .meetingTimes(List.of(
-                            MeetingTime.of(DayOfWeek.TUE, LocalTime.parse("13:30"), LocalTime.parse("15:00")),
-                            MeetingTime.of(DayOfWeek.THU, LocalTime.parse("13:30"), LocalTime.parse("15:00"))))
-                    .build();
-            sectionRepository.save(osSection2);
-
-            // 2. 데이터베이스
-            Subject db = Subject.builder()
-                    .name("데이터베이스")
-                    .credit(3)
-                    .semester(SemesterEnum.FIRST_SEMESTER)
-                    .build();
-            Subject savedDb = subjectRepository.save(db);
-
-            Section dbSection = Section.builder()
-                    .subjectId(savedDb.getSubjectId())
-                    .sectionNumber("01")
-                    .professor("이영희 교수")
-                    .yearId("2024")
-                    .semester(SemesterEnum.FIRST_SEMESTER)
-                    .meetingTimes(List.of(
-                            MeetingTime.of(DayOfWeek.FRI, LocalTime.parse("10:00"), LocalTime.parse("13:00"))))
-                    .build();
-            sectionRepository.save(dbSection);
-
-            // 3. 알고리즘
-            Subject algo = Subject.builder()
-                    .name("알고리즘")
-                    .credit(3)
-                    .semester(SemesterEnum.FIRST_SEMESTER)
-                    .build();
-            Subject savedAlgo = subjectRepository.save(algo);
-
-            Section algoSection = Section.builder()
-                    .subjectId(savedAlgo.getSubjectId())
-                    .sectionNumber("01")
-                    .professor("박지성 교수")
-                    .yearId("2024")
-                    .semester(SemesterEnum.FIRST_SEMESTER)
-                    .meetingTimes(List.of(
-                            MeetingTime.of(DayOfWeek.MON, LocalTime.parse("15:00"), LocalTime.parse("16:30")),
-                            MeetingTime.of(DayOfWeek.WED, LocalTime.parse("15:00"), LocalTime.parse("16:30"))))
-                    .build();
-            sectionRepository.save(algoSection);
-
-            log.info("시드 데이터 삽입 완료!");
+        private void createCollectionIfNotExists(String collectionName) {
+                try {
+                        if (!mongoTemplate.collectionExists(collectionName)) {
+                                mongoTemplate.createCollection(collectionName);
+                                log.info("Created collection: {}", collectionName);
+                        }
+                } catch (Exception e) {
+                        log.warn("Error creating collection {}: {}", collectionName, e.getMessage());
+                }
         }
-    }
+
+        private void initSeedData() {
+                // 개발/테스트용: 기존 데이터 초기화 후 다시 삽입
+                subjectRepository.deleteAll();
+                sectionRepository.deleteAll();
+
+                if (subjectRepository.count() == 0) {
+                        log.info("시드 데이터 삽입 중...");
+
+                        // 1. 운영체제
+                        Subject os = Subject.builder()
+                                        .subjectId("subject-os-001")
+                                        .name("운영체제")
+                                        .credit(3)
+                                        .semester(SemesterEnum.FIRST_SEMESTER)
+                                        .categoryId("CAT_COMPUTER_SCIENCE")
+                                        .build();
+                        Subject savedOs = subjectRepository.save(os);
+
+                        Section osSection1 = Section.builder()
+                                        .subjectId(savedOs.getSubjectId())
+                                        .sectionNumber("01")
+                                        .professor("홍길동 교수")
+                                        .yearId("2024")
+                                        .semester(SemesterEnum.FIRST_SEMESTER)
+                                        .meetingTimes(List.of(
+                                                        MeetingTime.of(DayOfWeek.MON, LocalTime.parse("09:00"),
+                                                                        LocalTime.parse("10:30")),
+                                                        MeetingTime.of(DayOfWeek.WED, LocalTime.parse("09:00"),
+                                                                        LocalTime.parse("10:30"))))
+                                        .build();
+                        sectionRepository.save(osSection1);
+
+                        Section osSection2 = Section.builder()
+                                        .subjectId(savedOs.getSubjectId())
+                                        .sectionNumber("02")
+                                        .professor("김철수 교수")
+                                        .yearId("2024")
+                                        .semester(SemesterEnum.FIRST_SEMESTER)
+                                        .meetingTimes(List.of(
+                                                        MeetingTime.of(DayOfWeek.TUE, LocalTime.parse("13:30"),
+                                                                        LocalTime.parse("15:00")),
+                                                        MeetingTime.of(DayOfWeek.THU, LocalTime.parse("13:30"),
+                                                                        LocalTime.parse("15:00"))))
+                                        .build();
+                        sectionRepository.save(osSection2);
+
+                        // 2. 데이터베이스
+                        Subject db = Subject.builder()
+                                        .subjectId("subject-db-001")
+                                        .name("데이터베이스")
+                                        .credit(3)
+                                        .semester(SemesterEnum.FIRST_SEMESTER)
+                                        .categoryId("CAT_COMPUTER_SCIENCE")
+                                        .build();
+                        Subject savedDb = subjectRepository.save(db);
+
+                        Section dbSection = Section.builder()
+                                        .subjectId(savedDb.getSubjectId())
+                                        .sectionNumber("01")
+                                        .professor("이영희 교수")
+                                        .yearId("2024")
+                                        .semester(SemesterEnum.FIRST_SEMESTER)
+                                        .meetingTimes(List.of(
+                                                        MeetingTime.of(DayOfWeek.FRI, LocalTime.parse("10:00"),
+                                                                        LocalTime.parse("13:00"))))
+                                        .build();
+                        sectionRepository.save(dbSection);
+
+                        // 3. 알고리즘
+                        Subject algo = Subject.builder()
+                                        .subjectId("subject-algo-001")
+                                        .name("알고리즘")
+                                        .credit(3)
+                                        .semester(SemesterEnum.FIRST_SEMESTER)
+                                        .categoryId("CAT_COMPUTER_SCIENCE")
+                                        .build();
+                        Subject savedAlgo = subjectRepository.save(algo);
+
+                        Section algoSection = Section.builder()
+                                        .subjectId(savedAlgo.getSubjectId())
+                                        .sectionNumber("01")
+                                        .professor("박지성 교수")
+                                        .yearId("2024")
+                                        .semester(SemesterEnum.FIRST_SEMESTER)
+                                        .meetingTimes(List.of(
+                                                        MeetingTime.of(DayOfWeek.MON, LocalTime.parse("15:00"),
+                                                                        LocalTime.parse("16:30")),
+                                                        MeetingTime.of(DayOfWeek.WED, LocalTime.parse("15:00"),
+                                                                        LocalTime.parse("16:30"))))
+                                        .build();
+                        sectionRepository.save(algoSection);
+
+                        // 4. 교양 (인문학) - 채움 알고리즘 테스트용
+                        Subject history = Subject.builder()
+                                        .subjectId("subject-history-001")
+                                        .name("역사의 이해")
+                                        .credit(2)
+                                        .semester(SemesterEnum.FIRST_SEMESTER)
+                                        .categoryId("CAT_HUMANITIES") // 인문학 카테고리
+                                        .build();
+                        Subject savedHistory = subjectRepository.save(history);
+
+                        Section historySection = Section.builder()
+                                        .subjectId(savedHistory.getSubjectId())
+                                        .sectionNumber("01")
+                                        .professor("최역사 교수")
+                                        .yearId("2024")
+                                        .semester(SemesterEnum.FIRST_SEMESTER)
+                                        .meetingTimes(List.of(
+                                                        MeetingTime.of(DayOfWeek.FRI, LocalTime.parse("14:00"),
+                                                                        LocalTime.parse("16:00"))))
+                                        .build();
+                        sectionRepository.save(historySection);
+
+                        // 5. 교양 (예술) - 채움 알고리즘 테스트용
+                        Subject art = Subject.builder()
+                                        .subjectId("subject-art-001")
+                                        .name("음악의 이해")
+                                        .credit(2)
+                                        .semester(SemesterEnum.FIRST_SEMESTER)
+                                        .categoryId("CAT_ARTS") // 예술 카테고리
+                                        .build();
+                        Subject savedArt = subjectRepository.save(art);
+
+                        Section artSection = Section.builder()
+                                        .subjectId(savedArt.getSubjectId())
+                                        .sectionNumber("01")
+                                        .professor("김음악 교수")
+                                        .yearId("2024")
+                                        .semester(SemesterEnum.FIRST_SEMESTER)
+                                        .meetingTimes(List.of(
+                                                        MeetingTime.of(DayOfWeek.TUE, LocalTime.parse("10:00"),
+                                                                        LocalTime.parse("12:00"))))
+                                        .build();
+                        sectionRepository.save(artSection);
+
+                        log.info("시드 데이터 삽입 완료!");
+                }
+        }
 }

--- a/src/main/java/com/gpyeong/core/global/swagger/TimetableApi.java
+++ b/src/main/java/com/gpyeong/core/global/swagger/TimetableApi.java
@@ -1,0 +1,25 @@
+package com.gpyeong.core.global.swagger;
+
+import com.gpyeong.core.domain.auth.domain.entity.User;
+import com.gpyeong.core.domain.timetable.application.dto.request.TimetableGenerationRequest;
+import com.gpyeong.core.domain.timetable.application.dto.response.TimetableGenerationResponse;
+import com.gpyeong.core.global.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "시간표 관리", description = "시간표 생성 및 조회 API")
+public interface TimetableApi {
+
+        @Operation(summary = "시간표 자동 생성", description = "사용자가 선택한 필수 과목과 선호 조건을 기반으로 최적의 시간표를 생성합니다.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "생성 성공 (생성된 시간표 ID 반환)"),
+                        @ApiResponse(responseCode = "400", description = "시간표 생성 실패 (조건 충돌)")
+        })
+        BaseResponse<TimetableGenerationResponse> generateTimetable(
+                        @Parameter(hidden = true) User user,
+                        @RequestBody TimetableGenerationRequest request);
+}

--- a/src/test/java/com/gpyeong/core/domain/timetable/application/usecase/TimetableGenerationUseCaseTest.java
+++ b/src/test/java/com/gpyeong/core/domain/timetable/application/usecase/TimetableGenerationUseCaseTest.java
@@ -1,0 +1,120 @@
+package com.gpyeong.core.domain.timetable.application.usecase;
+
+import com.gpyeong.core.domain.common.domain.entity.SemesterEnum;
+import com.gpyeong.core.domain.curriculum.domain.entity.Subject;
+import com.gpyeong.core.domain.curriculum.domain.repository.SectionRepository;
+import com.gpyeong.core.domain.curriculum.domain.repository.SubjectRepository;
+import com.gpyeong.core.domain.timetable.application.dto.request.TimetableGenerationRequest;
+import com.gpyeong.core.domain.timetable.domain.entity.Timetable;
+import com.gpyeong.core.domain.timetable.domain.entity.TimetableItem;
+import com.gpyeong.core.domain.timetable.domain.repository.TimetableItemRepository;
+import com.gpyeong.core.domain.timetable.domain.repository.TimetableRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.DayOfWeek;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class TimetableGenerationUseCaseTest {
+
+        @Autowired
+        private TimetableGenerationUseCase timetableGenerationUseCase;
+
+        // Service might be needed for direct testing later, but UseCase test covers
+        // integration for now.
+
+        @Autowired
+        private SubjectRepository subjectRepository;
+
+        @Autowired
+        private TimetableRepository timetableRepository;
+
+        @Autowired
+        private TimetableItemRepository timetableItemRepository;
+
+        @Autowired
+        private SectionRepository sectionRepository;
+
+        @Test
+        void generateTimetable_ShouldFillElectives() {
+                // Given
+                // 1. 필수 과목 "알고리즘" (3학점) ID 조회
+                Subject algo = subjectRepository.findAll().stream()
+                                .filter(s -> "알고리즘".equals(s.getName()))
+                                .findFirst()
+                                .orElseThrow(() -> new IllegalStateException("알고리즘 과목이 시드 데이터에 없습니다."));
+
+                // 2. 교양 카테고리 "CAT_HUMANITIES" (역사의 이해, 2학점)
+                // 목표 학점: 5점 (알고리즘 3 + 교양 2)
+
+                TimetableGenerationRequest request = new TimetableGenerationRequest(
+                                "2024",
+                                SemesterEnum.FIRST_SEMESTER,
+                                5, // Target Credits
+                                List.of(algo.getSubjectId()), // Required: Algorithm
+                                List.of("CAT_HUMANITIES"), // Preferred Category
+                                List.of(), // Preferred Day Offs
+                                false // Avoid Morning
+                );
+
+                // When
+                String timetableId = timetableGenerationUseCase.generate(1, request);
+
+                // Then
+                assertThat(timetableId).isNotNull();
+
+                Timetable timetable = timetableRepository.findById(timetableId).orElseThrow();
+                assertThat(timetable.getTotalCredit()).isGreaterThanOrEqualTo(5);
+                assertThat(timetable.getSummary()).isEqualTo("자동 생성된 시간표");
+        }
+
+        @Test
+        void generateTimetable_ShouldPreferCompactSchedule() {
+                // Given
+                // 1. 필수 과목: 알고리즘 (월, 수 15:00 ~ 16:30)
+                Subject algo = subjectRepository.findAll().stream()
+                                .filter(s -> "알고리즘".equals(s.getName()))
+                                .findFirst()
+                                .orElseThrow();
+
+                // 2. 교양 과목 후보: 컴퓨터 사이언스 (운영체제)
+                // - 분반 1 (01): 월, 수 09:00 ~ 10:30 (알고리즘과 긴 공강 발생)
+                // - 분반 2 (02): 화, 목 13:30 ~ 15:00 (공강 없음, 가장 선호되어야 함)
+
+                TimetableGenerationRequest request = new TimetableGenerationRequest(
+                                "2024",
+                                SemesterEnum.FIRST_SEMESTER,
+                                6, // Target Credits (Algo 3 + OS 3)
+                                List.of(algo.getSubjectId()),
+                                List.of("CAT_COMPUTER_SCIENCE"),
+                                List.of(), // No specific preference
+                                false // "오전 수업 상관 없음" -> Compactness 가 중요해짐
+                );
+
+                // When
+                String timetableId = timetableGenerationUseCase.generate(1, request);
+
+                // Then
+                assertThat(timetableId).isNotNull();
+
+                // 생성된 시간표의 아이템 조회
+                List<TimetableItem> items = timetableItemRepository.findByTimetableId(timetableId);
+                List<String> sectionIds = items.stream().map(TimetableItem::getSectionId).toList();
+                var sections = sectionRepository.findAllById(sectionIds);
+
+                // "화요일" 수업이 포함되어 있는지 확인 (분반 2가 화/목이므로)
+                boolean hasTueClass = sections.stream()
+                                .flatMap(s -> s.getMeetingTimes().stream())
+                                .anyMatch(mt -> mt
+                                                .getDayOfWeek() == com.gpyeong.core.domain.curriculum.domain.entity.DayOfWeek.TUE);
+
+                assertThat(hasTueClass).as("공강이 적은 화목 오후 분반(02)이 선택되어야 합니다.")
+                                .isTrue();
+        }
+}


### PR DESCRIPTION
### 📝 요약 (Summary)
- 시간표 생성 로직 구현 
- 생성된 시간표를 조회할 수 있는 API를 추가

### 🛠️ 주요 변경 사항 (Changes)
**1. 알고리즘 고도화 (Algorithm Improvements)**
*   **Beam Search 도입**: 기존의 단순 Greedy 방식에서 Beam Search(K=5)로 변경하여 더 나은 시간표 조합을 탐색합니다.
*   **학점 정밀도 우선 로직**: 교양 과목 채움 시, 단순 점수보다 **목표 학점과의 오차(`|현재-목표|`)가 가장 적은 조합**을 최우선으로 선택하도록 개선했습니다.
    *   *효과*: 7학점 목표 시 9학점(3+3+3)이 아닌 7학점(3+2+2) 조합이 정확히 선택됨.
*   **성능 최적화**: 정렬 과정에서 발생할 수 있는 N+1 문제를 방지하기 위해 `subjectCreditMap`을 도입하여 학점 조회 성능을 개선했습니다.

**2. 시간표 조회 **
*   **시간표 조회 API**: `GET /api/timetables/{timetableId}` 엔드포인트 구현
    *   `TimetableQueryUseCase`, `TimetableController` 추가
    *   Response DTO (`TimetableResponse`, `TimetableItemResponse`) 설계 및 적용


### ✅ 영향 범위 (Impact)
*   `/api/timetables/generate`: 생성 로직 변경됨 (더 정확함)
*   `/api/timetables/{id}`: 신규 API

### 관련 이슈: https://github.com/G-Pyeong/G-Pyeong-BE/issues/16